### PR TITLE
Upgrade jacoco to version 0.7.6.201602180812

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ lazy val root = (project in file(".")).enablePlugins(BuildInfoPlugin).settings(
 
   name := "jacoco4sbt",
   organization := "de.johoop",
-  version := "2.2.0",
+  version := "2.3.0",
   scalaVersion := "2.10.6",
 
   sbtPlugin := true,
@@ -29,4 +29,4 @@ lazy val root = (project in file(".")).enablePlugins(BuildInfoPlugin).settings(
 
 lazy val jacocoCore    = Artifact("org.jacoco.core", "jar", "jar")
 lazy val jacocoReport  = Artifact("org.jacoco.report", "jar", "jar")
-lazy val jacocoVersion = "0.7.5.201505241946"
+lazy val jacocoVersion = "0.7.6.201602180812"

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ lazy val root = (project in file(".")).enablePlugins(BuildInfoPlugin).settings(
 
   name := "jacoco4sbt",
   organization := "de.johoop",
-  version := "2.3.0",
+  version := "2.3.0-SNAPSHOT",
   scalaVersion := "2.10.6",
 
   sbtPlugin := true,

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ lazy val root = (project in file(".")).enablePlugins(BuildInfoPlugin).settings(
 
   scalacOptions ++= Seq("-unchecked", "-deprecation", "-language:_"),
 
-  buildInfoKeys := Seq[BuildInfoKey](resourceDirectory in Test),
+  buildInfoKeys := Seq[BuildInfoKey](resourceDirectory in Test, version),
   buildInfoPackage := "de.johoop.jacoco4sbt.build",
 
   test in Test <<= test in Test dependsOn publishLocal,

--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ See [Wiki](https://github.com/sbt/jacoco4sbt/wiki) for more details.
 
 ## Change Log
 
-* *2.3.0*
+* *2.3.0* _(unreleased)_
 
     * Update to JaCoCo version 0.7.6 ([#67](https://github.com/sbt/jacoco4sbt/pull/67))
 

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,10 @@ See [Wiki](https://github.com/sbt/jacoco4sbt/wiki) for more details.
 
 ## Change Log
 
+* *2.3.0*
+
+    * Update to JaCoCo version 0.7.6 ([#67](https://github.com/sbt/jacoco4sbt/pull/67))
+
 * *2.2.0*
 
     * Update to JaCoCo version 0.7.5 (fixing [#47](https://github.com/sbt/jacoco4sbt/issues/47))

--- a/src/main/scala/de/johoop/jacoco4sbt/JacocoPlugin.scala
+++ b/src/main/scala/de/johoop/jacoco4sbt/JacocoPlugin.scala
@@ -98,7 +98,7 @@ object JacocoPlugin extends Plugin {
     def settings = Seq(
       ivyConfigurations += Config,
       libraryDependencies +=
-        "org.jacoco" % "org.jacoco.agent" % "0.7.5.201505241946" % "jacoco" artifacts Artifact("org.jacoco.agent", "jar", "jar")
+        "org.jacoco" % "org.jacoco.agent" % "0.7.6.201602180812" % "jacoco" artifacts Artifact("org.jacoco.agent", "jar", "jar")
     ) ++ inConfig(Config)(Defaults.testSettings ++ JacocoDefaults.settings ++ Seq(
       classesToCover <<= (classDirectory in Compile, includes, excludes) map filterClassesToCover,
       aggregateClassesToCover := submoduleSettings.value.flatMap(_._1).flatten.distinct,

--- a/src/main/scala/de/johoop/jacoco4sbt/filter/FilteringClassAnalyzer.scala
+++ b/src/main/scala/de/johoop/jacoco4sbt/filter/FilteringClassAnalyzer.scala
@@ -11,17 +11,17 @@
  */
 package de.johoop.jacoco4sbt.filter
 
-import scala.collection.mutable
+import org.jacoco.core.analysis.{Analyzer, ICoverageVisitor, IMethodCoverage}
+import org.jacoco.core.data.ExecutionDataStore
 import org.jacoco.core.internal.analysis.{ClassAnalyzer, ClassCoverageImpl, MethodAnalyzer, StringPool}
+import org.jacoco.core.internal.data.CRC64
 import org.jacoco.core.internal.flow.{ClassProbesAdapter, MethodProbesVisitor}
 import org.jacoco.core.internal.instr.InstrSupport
 import org.objectweb.asm._
-import org.jacoco.core.analysis.{Analyzer, ICoverageVisitor, IMethodCoverage}
-import org.jacoco.core.internal.data.CRC64
-import org.jacoco.core.data.ExecutionDataStore
-import org.objectweb.asm.tree.{ClassNode, JumpInsnNode, MethodInsnNode, MethodNode}
+import org.objectweb.asm.tree.{ClassNode, MethodNode}
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable
 
 /**
  * Filters coverage results from Scala synthetic methods:
@@ -83,8 +83,10 @@ private final class FilteringClassAnalyzer(classCoverage: ClassCoverageImpl, cla
   }
 
   private def ignore(mc: IMethodCoverage, node: MethodNode): Boolean = {
+    import AccessorDetector._
+    import ScalaForwarderDetector._
+    import ScalaSyntheticMethod._
     import node.name
-    import ScalaSyntheticMethod._, ScalaForwarderDetector._, AccessorDetector._
     def isModuleStaticInit = isModuleClass && name == "<clinit>"
 
     (

--- a/src/test/resources/jacocoIntegrationTest/project/plugins.sbt
+++ b/src/test/resources/jacocoIntegrationTest/project/plugins.sbt
@@ -2,7 +2,7 @@
   val pluginVersion = System.getProperty("plugin.version")
   if (pluginVersion == null)
     throw new RuntimeException("""|The system property 'plugin.version' is not defined.
-                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+                                  |Specify this property using the parameter -Dplugin.version=<version>""".stripMargin)
 
   else addSbtPlugin("de.johoop" % "jacoco4sbt" % pluginVersion)
 }

--- a/src/test/resources/jacocoIntegrationTest/project/plugins.sbt
+++ b/src/test/resources/jacocoIntegrationTest/project/plugins.sbt
@@ -1,1 +1,8 @@
-addSbtPlugin("de.johoop" % "jacoco4sbt" % "2.2.0")
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if (pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+
+  else addSbtPlugin("de.johoop" % "jacoco4sbt" % pluginVersion)
+}

--- a/src/test/resources/jacocoTest/project/plugins.sbt
+++ b/src/test/resources/jacocoTest/project/plugins.sbt
@@ -2,7 +2,7 @@
   val pluginVersion = System.getProperty("plugin.version")
   if (pluginVersion == null)
     throw new RuntimeException("""|The system property 'plugin.version' is not defined.
-                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+                                  |Specify this property using the parameter -Dplugin.version=<version>""".stripMargin)
 
   else addSbtPlugin("de.johoop" % "jacoco4sbt" % pluginVersion)
 }

--- a/src/test/resources/jacocoTest/project/plugins.sbt
+++ b/src/test/resources/jacocoTest/project/plugins.sbt
@@ -1,1 +1,8 @@
-addSbtPlugin("de.johoop" % "jacoco4sbt" % "2.2.0")
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if (pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+
+  else addSbtPlugin("de.johoop" % "jacoco4sbt" % pluginVersion)
+}

--- a/src/test/resources/jacocoTestForked/project/plugins.sbt
+++ b/src/test/resources/jacocoTestForked/project/plugins.sbt
@@ -2,7 +2,7 @@
   val pluginVersion = System.getProperty("plugin.version")
   if (pluginVersion == null)
     throw new RuntimeException("""|The system property 'plugin.version' is not defined.
-                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+                                  |Specify this property using the parameter -Dplugin.version=<version>""".stripMargin)
 
   else addSbtPlugin("de.johoop" % "jacoco4sbt" % pluginVersion)
 }

--- a/src/test/resources/jacocoTestForked/project/plugins.sbt
+++ b/src/test/resources/jacocoTestForked/project/plugins.sbt
@@ -1,1 +1,8 @@
-addSbtPlugin("de.johoop" % "jacoco4sbt" % "2.2.0")
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if (pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+
+  else addSbtPlugin("de.johoop" % "jacoco4sbt" % pluginVersion)
+}

--- a/src/test/resources/play-multi-project-jacoco/project/plugins.sbt
+++ b/src/test/resources/play-multi-project-jacoco/project/plugins.sbt
@@ -11,7 +11,7 @@ addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.2.1")
   val pluginVersion = System.getProperty("plugin.version")
   if (pluginVersion == null)
     throw new RuntimeException("""|The system property 'plugin.version' is not defined.
-                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+                                  |Specify this property using the parameter -Dplugin.version=<version>""".stripMargin)
 
   else addSbtPlugin("de.johoop" % "jacoco4sbt" % pluginVersion)
 }

--- a/src/test/resources/play-multi-project-jacoco/project/plugins.sbt
+++ b/src/test/resources/play-multi-project-jacoco/project/plugins.sbt
@@ -7,4 +7,11 @@ resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/release
 // Use the Play sbt plugin for Play projects
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.2.1")
 
-addSbtPlugin("de.johoop" % "jacoco4sbt" % "2.2.0")
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if (pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+
+  else addSbtPlugin("de.johoop" % "jacoco4sbt" % pluginVersion)
+}

--- a/src/test/scala/de/johoop/jacoco4sbt/ForkedSImpleScalaProjectCoverageSpec.scala
+++ b/src/test/scala/de/johoop/jacoco4sbt/ForkedSImpleScalaProjectCoverageSpec.scala
@@ -20,7 +20,7 @@ class ForkedSimpleScalaProjectCoverageSpec extends Specification with FileMatche
   lazy val jacocoDir = new File(targetDir, "scala-2.10/jacoco")
   lazy val coveredClassesDir = new File(jacocoDir, "classes")
 
-  lazy val exitCode = Process(Seq(Util.processName, "clean", "jacoco:cover"), Some(testProjectBase)) !
+  lazy val exitCode = Process(Seq(Util.processName, s"-Dplugin.version=${BuildInfo.version}", "clean", "jacoco:cover"), Some(testProjectBase)) !
 
   def e1 = exitCode should be equalTo 0
   def e2 = jacocoDir should exist and beADirectory

--- a/src/test/scala/de/johoop/jacoco4sbt/IntegrationTestScalaProjectCoverageSpec.scala
+++ b/src/test/scala/de/johoop/jacoco4sbt/IntegrationTestScalaProjectCoverageSpec.scala
@@ -24,7 +24,7 @@ class IntegrationTestScalaProjectCoverageSpec extends Specification with FileMat
   lazy val coveredClassesDir = new File(jacocoDir, "classes")
   lazy val coveredItClassesDir = new File(itJacocoDir, "classes")
 
-  lazy val exitCode = Process(s"${Util.processName} clean jacoco:cover it-jacoco:cover", Some(testProjectBase)) !
+  lazy val exitCode = Process(s"${Util.processName} -Dplugin.version=${BuildInfo.version} clean jacoco:cover it-jacoco:cover", Some(testProjectBase)) !
 
   def e1 = exitCode should be equalTo(0)
   def e2 = jacocoDir should exist and beADirectory

--- a/src/test/scala/de/johoop/jacoco4sbt/PlayJavaMultiProjectCoverageSpec.scala
+++ b/src/test/scala/de/johoop/jacoco4sbt/PlayJavaMultiProjectCoverageSpec.scala
@@ -29,7 +29,7 @@ class PlayJavaMultiProjectCoverageSpec extends Specification with FileMatchers {
   } yield new File(targetDir, reportPath)
   lazy val aggregateReport = new File(testProjectBase, "target/scala-2.10/jacoco/aggregate/html")
 
-  lazy val exitCode = Process(s"${Util.processName} clean jacoco:aggregate-cover", Some(testProjectBase)) !
+  lazy val exitCode = Process(s"${Util.processName} -Dplugin.version=${BuildInfo.version} clean jacoco:aggregate-cover", Some(testProjectBase)) !
 
   def e1 = exitCode should be equalTo(0)
   def e2 = jacocoDirs should contain(exist and beADirectory).foreach

--- a/src/test/scala/de/johoop/jacoco4sbt/SimpleScalaProjectCoverageSpec.scala
+++ b/src/test/scala/de/johoop/jacoco4sbt/SimpleScalaProjectCoverageSpec.scala
@@ -20,7 +20,7 @@ class SimpleScalaProjectCoverageSpec extends Specification with FileMatchers { d
   lazy val jacocoDir = new File(targetDir, "scala-2.10/jacoco")
   lazy val coveredClassesDir = new File(jacocoDir, "classes")
 
-  lazy val exitCode = Process(s"${Util.processName} clean jacoco:cover", Some(testProjectBase)) !
+  lazy val exitCode = Process(s"${Util.processName} -Dplugin.version=${BuildInfo.version} clean jacoco:cover", Some(testProjectBase)) !
 
   def e1 = exitCode should not be equalTo(0)
   def e2 = jacocoDir should exist and beADirectory


### PR DESCRIPTION
This provides a bump to jacoco version `0.7.6` which includes an interface change. I've provided minimal refactoring to integrate with this change.

Interface change in question can be found here: https://github.com/jacoco/jacoco/commit/f4622217085198f3ae42906934026961b29d1111

This change prepares `jacoco4sbt` for further jacoco upgrades, tested to version `0.7.9` without need for any other code changes.