### PR TITLE
Upgrade to jacoco version 0.7.9

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ lazy val root = (project in file(".")).enablePlugins(BuildInfoPlugin).settings(
 
   name := "jacoco4sbt",
   organization := "de.johoop",
-  version := "2.3.0",
+  version := "2.4.0-SNAPSHOT",
   scalaVersion := "2.10.6",
 
   sbtPlugin := true,
@@ -19,7 +19,7 @@ lazy val root = (project in file(".")).enablePlugins(BuildInfoPlugin).settings(
 
   scalacOptions ++= Seq("-unchecked", "-deprecation", "-language:_"),
 
-  buildInfoKeys := Seq[BuildInfoKey](resourceDirectory in Test, version),
+  buildInfoKeys := Seq[BuildInfoKey](resourceDirectory in Test, version, "jacocoVersion" -> jacocoVersion),
   buildInfoPackage := "de.johoop.jacoco4sbt.build",
 
   test in Test <<= test in Test dependsOn publishLocal,
@@ -29,4 +29,4 @@ lazy val root = (project in file(".")).enablePlugins(BuildInfoPlugin).settings(
 
 lazy val jacocoCore    = Artifact("org.jacoco.core", "jar", "jar")
 lazy val jacocoReport  = Artifact("org.jacoco.report", "jar", "jar")
-lazy val jacocoVersion = "0.7.6.201602180812"
+lazy val jacocoVersion = "0.7.9"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
 

--- a/src/main/scala/de/johoop/jacoco4sbt/JacocoPlugin.scala
+++ b/src/main/scala/de/johoop/jacoco4sbt/JacocoPlugin.scala
@@ -14,6 +14,8 @@ package de.johoop.jacoco4sbt
 import sbt._
 import Keys._
 import java.io.File
+
+import de.johoop.jacoco4sbt.build.BuildInfo
 import inc.Locate
 
 object JacocoPlugin extends Plugin {
@@ -98,7 +100,7 @@ object JacocoPlugin extends Plugin {
     def settings = Seq(
       ivyConfigurations += Config,
       libraryDependencies +=
-        "org.jacoco" % "org.jacoco.agent" % "0.7.6.201602180812" % "jacoco" artifacts Artifact("org.jacoco.agent", "jar", "jar")
+        "org.jacoco" % "org.jacoco.agent" % BuildInfo.jacocoVersion % "jacoco" artifacts Artifact("org.jacoco.agent", "jar", "jar")
     ) ++ inConfig(Config)(Defaults.testSettings ++ JacocoDefaults.settings ++ Seq(
       classesToCover <<= (classDirectory in Compile, includes, excludes) map filterClassesToCover,
       aggregateClassesToCover := submoduleSettings.value.flatMap(_._1).flatten.distinct,


### PR DESCRIPTION
This upgrades to jacoco version `0.7.9` but additionally places the jacocoVersion into the `BuildInfo` so we don't need to specify it in multiple places.